### PR TITLE
Details fix: remove redundant "await" statements

### DIFF
--- a/lib/app/modules/login/domain/usecases/get_logged_user.dart
+++ b/lib/app/modules/login/domain/usecases/get_logged_user.dart
@@ -18,6 +18,6 @@ class GetLoggedUserImpl implements GetLoggedUser {
 
   @override
   Future<Either<Failure, LoggedUserInfo>> call() async {
-    return await repository.loggedUser();
+    return repository.loggedUser();
   }
 }

--- a/lib/app/modules/login/domain/usecases/login_with_email.dart
+++ b/lib/app/modules/login/domain/usecases/login_with_email.dart
@@ -35,7 +35,7 @@ class LoginWithEmailImpl implements LoginWithEmail {
       return Left(ErrorLoginEmail(message: "Invalid Password"));
     }
 
-    return await repository.loginEmail(
+    return repository.loginEmail(
       email: credential.email,
       password: credential.password,
     );

--- a/lib/app/modules/login/domain/usecases/login_with_phone.dart
+++ b/lib/app/modules/login/domain/usecases/login_with_phone.dart
@@ -29,6 +29,7 @@ class LoginWithPhoneImpl implements LoginWithPhone {
     if (result.isLeft()) {
       return result.map((r) => null);
     }
-    return await repository.loginPhone(phone: credencial.phone);
+    
+    return repository.loginPhone(phone: credencial.phone);
   }
 }

--- a/lib/app/modules/login/domain/usecases/logout.dart
+++ b/lib/app/modules/login/domain/usecases/logout.dart
@@ -17,6 +17,6 @@ class LogoutImpl implements Logout {
 
   @override
   Future<Either<Failure, Unit>> call() async {
-    return await repository.logout();
+    return repository.logout();
   }
 }

--- a/lib/app/modules/login/external/datasources/firebase_datasource.dart
+++ b/lib/app/modules/login/external/datasources/firebase_datasource.dart
@@ -80,6 +80,6 @@ class FirebaseDataSourceImpl implements LoginDataSource {
 
   @override
   Future<void> logout() async {
-    return await auth.signOut();
+    await auth.signOut();
   }
 }


### PR DESCRIPTION
Remove some "await" statements that are redundant, because the return of called method already returns a method type, example:
```dart
 Future<Either<Failure, LoggedUserInfo>> call(
    ...
    return await repository.loginEmail(
      email: credential.email,
      password: credential.password,
    );
  }
}
```
Since repository.loginEmail() already returns a `Future<Either<Failure, LoggedUserInfo>>`, then the await is unnecessary along with return statement, to fix this:
```dart
 Future<Either<Failure, LoggedUserInfo>> call(
    ...
    return repository.loginEmail(
      email: credential.email,
      password: credential.password,
    );
  }
}
```
Despite being a simple code fix, any revision and error correction on my part is welcome! Thanks